### PR TITLE
[Exceptions] Fix wrong wording for ErrorClass description.

### DIFF
--- a/_src/content/language/exceptions/_raise.md
+++ b/_src/content/language/exceptions/_raise.md
@@ -8,6 +8,6 @@ Exceptions are raised with the [`Kernel#raise`](ref:Kernel#raise) method. It has
     raise "Some message" # RuntimeError with custom message
     raise ErrorClass, "Some message" # Custom error with custom message
 
-`ErrorClass` should be a subclass of [Exception](../builtin/exception.md).
+`ErrorClass` must be a subclass of [Exception](../builtin/exception.md).
 
 See [`Kernel#raise`](ref:Kernel#raise) for more details on raising exceptions.

--- a/language/exceptions.md
+++ b/language/exceptions.md
@@ -20,7 +20,7 @@ raise "Some message" # RuntimeError with custom message
 raise ErrorClass, "Some message" # Custom error with custom message
 ```
 
-`ErrorClass` should be a subclass of
+`ErrorClass` must be a subclass of
 [Exception](../builtin/exception.md).
 
 See <a href='https://ruby-doc.org/core-2.5.0/Kernel.html#method-i-raise'


### PR DESCRIPTION
The word "should" is used mainly for advice.
The word "must" is much stronger and used for orders.

#### Example
```
ErrorClass should be a subclass of Exception
```
That means it could be any other class as well, we just recommend doing it that way.

```
ErrorClass must be a subclass of Exception.
```
In this case, you **absolutely** can't use any other classes that aren't subclasses of Exception, otherwise you would get the error `exception class/object expected`.