### PR TITLE
Update URLs for pry

### DIFF
--- a/_src/config/structure.yml
+++ b/_src/config/structure.yml
@@ -31,7 +31,7 @@
             - "## Usage"
             # "Use of irb is easy if you know Ruby." does not look friendly in book intro :)
             - "Use of irb is easy"
-        - source: "> Another popular Ruby interactive console is [pry](http://pryrepl.org/)."
+        - source: "> Another popular Ruby interactive console is [pry](https://pry.github.io/)."
         - source: lib/irb/XMP.md
           ignore: true
     - title: Ruby in Twenty Minutes

--- a/intro/irb.md
+++ b/intro/irb.md
@@ -38,7 +38,7 @@ There are a few variables in every Irb session that can come in handy:
 
 
 
-> Another popular Ruby interactive console is <a href='http://pryrepl.org/' class='remote' target='_blank'>pry</a>.
+> Another popular Ruby interactive console is <a href='https://pry.github.io/' class='remote' target='_blank'>pry</a>.
 
 
 


### PR DESCRIPTION
The old domain appears to have expired and now redirects to `https://cobaltbluemedia.com/pryrepl/`